### PR TITLE
Fix column marks not saving settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from cudatext import *
+import cudax_lib as apx
 
 def do_jump(is_next):
     carets = ed.get_carets()
@@ -53,11 +54,11 @@ class Command:
         s = dlg_input('Fixed margin:', s)
         if s is None: return
         ed.set_prop(PROP_MARGIN, s)
-        ed_bro.set_prop(PROP_MARGIN, s)
+        apx.set_opt('margin', s)
 
     def set_margins(self):
         s = ed.get_prop(PROP_MARGIN_STRING)
         s = dlg_input('Additional margins (space separated):', s)
         if s is None: return
         ed.set_prop(PROP_MARGIN_STRING, s)
-        ed_bro.set_prop(PROP_MARGIN_STRING, s)
+        apx.set_opt('margin_string', s)


### PR DESCRIPTION
Hello,

This is a PR to fix an issue I was having where the CudaText Column Marks
plugin was not saving margin settings to user.json and giving an error:

```python
    ed_bro.set_prop(PROP_MARGIN, s)
NameError: name 'ed_bro' is not defined
ERROR: Exception in CudaText for set_margin: NameError: name 'ed_bro' is not defined
```

It looks like this may have been an issue with an API change? I looked at other
plugins and the wiki for guidance and this is what worked for me. It now sets
and saves without error.

I have not contributed to CudaText before so I hope that I did it the correct way.
If there is anything I should change please let me know.

Thanks!